### PR TITLE
Remove unwanted storage_type from volume dictionary in VMAX driver

### DIFF
--- a/dolphin/drivers/dell_emc/vmax/client.py
+++ b/dolphin/drivers/dell_emc/vmax/client.py
@@ -165,7 +165,6 @@ class VMAXClient(object):
                     "status": status,
                     "original_id": vol['volumeId'],
                     "wwn": vol['wwn'],
-                    "storage_type": constants.StorageType.BLOCK,
                     "total_capacity": int(total_cap),
                     "used_capacity": int(used_cap),
                     "free_capacity": int(free_cap),


### PR DESCRIPTION
Remove unwanted storage_type from volume dictionary in VMAX driver



**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
