### PR TITLE
Fix for GET pool/<pool_id> has no response issue

### DIFF
--- a/dolphin/api/v1/pools.py
+++ b/dolphin/api/v1/pools.py
@@ -31,10 +31,10 @@ class PoolController(wsgi.Controller):
         """Return pools search options allowed ."""
         return self.search_options
 
-    def show(self, req, pool_id):
+    def show(self, req, id):
         ctxt = req.environ['dolphin.context']
         try:
-            pool = db.pool_get(ctxt, pool_id)
+            pool = db.pool_get(ctxt, id)
         except exception.PoolNotFound as e:
             raise exc.HTTPNotFound(explanation=e.msg)
         return pool_view.build_pool(pool)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix an issue encountered while refactoring GET Pool, 
pool_id was used before in show function for generalising show for mutiple GET.
now show is directly called from router, so we need to use 'id' insttead of pool_id"

**Which issue this PR fixes** 
NA
**Special notes for your reviewer**:

**Test eport**:
![image](https://user-images.githubusercontent.com/45681499/83016488-a6338700-a03f-11ea-9e91-32b52c618229.png)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
