### PR TITLE
Fix the bug that put snmpv3 alert failed.

### DIFF
--- a/dolphin/api/v1/alert.py
+++ b/dolphin/api/v1/alert.py
@@ -98,10 +98,6 @@ class AlertController(wsgi.Controller):
             user_name = alert_source.get('username')
             security_level = alert_source.get('security_level')
             engine_id = alert_source.get('engine_id')
-            alert_source['auth_key'] = None
-            alert_source['auth_protocol'] = None
-            alert_source['privacy_key'] = None
-            alert_source['privacy_protocol'] = None
             if not user_name or not security_level or not engine_id:
                 msg = "If snmp version is SNMPv3, then username, " \
                       "security_level and engine_id are required."
@@ -128,6 +124,14 @@ class AlertController(wsgi.Controller):
                         raise exception.InvalidInput(reason=msg)
                     alert_source['privacy_key'] = cryptor.encode(
                         alert_source['privacy_key'])
+                else:
+                    alert_source['privacy_key'] = None
+                    alert_source['privacy_protocol'] = None
+            else:
+                alert_source['auth_key'] = None
+                alert_source['auth_protocol'] = None
+                alert_source['privacy_key'] = None
+                alert_source['privacy_protocol'] = None
 
             # Clear keys for other versions.
             alert_source['community_string'] = None


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To fix the issue that put snmpv3 alert_source failed.
Test report:
![put_snmpv3_alert_source_succeed](https://user-images.githubusercontent.com/38932432/83114353-721d9c00-a0fb-11ea-8f06-135bdd1cf205.png)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #139 

**Special notes for your reviewer**:
As we need to consider the scenario that user put parameters more than required, for example, put auth_privacy_protocal with security_level as AuthNoPriv which not need auth_privacy_protocal, then we have to abandon those parameters. Those statement to assign None is for this.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
