### PR TITLE
Add sync status

### DIFF
--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -234,13 +234,13 @@ def _set_synced_if_ok(context, storage_id):
     try:
         storage = db.storage_get(context, storage_id)
     except exception.StorageNotFound:
-        msg = 'storage %s not found when try to set sync_status' \
+        msg = 'Storage %s not found when try to set sync_status' \
               % storage_id
         raise exception.InvalidInput(reason=msg)
     else:
         if storage[constants.DB.DEVICE_SYNC_STATUS] != \
                 constants.SyncStatus.SYNCED:
-            msg = 'sync task is running for %s' % storage['id']
+            msg = 'Sync task is running for %s' % storage['id']
             raise exception.InvalidInput(reason=msg)
         # Set all bits of sync_status to SYNCING and start sync tasks
         storage[constants.DB.DEVICE_SYNC_STATUS] = utils.set_bits(

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -21,6 +21,7 @@ from webob import exc
 from dolphin import context
 from dolphin import coordination
 from dolphin import db
+from dolphin import utils
 from dolphin import exception
 from dolphin.api import api_utils
 from dolphin.api import validation
@@ -159,6 +160,14 @@ class StorageController(wsgi.Controller):
                     constants.SyncStatus.SYNCED:
                 LOG.warn('sync task is running for %s' % storage['id'])
                 continue
+            # Set all bits of sync_status to SYNCING and start sync tasks
+            storage[constants.DB.DEVICE_SYNC_STATUS] = utils.set_bits(
+                storage[constants.DB.DEVICE_SYNC_STATUS],
+                0,
+                len(constants.ResourceType) - 1,
+                constants.SyncStatus.SYNCING)
+            db.storage_update(ctxt, storage['id'], storage)
+
             for subclass in task.StorageResourceTask.__subclasses__():
                 self.task_rpcapi.sync_storage_resource(
                     ctxt,
@@ -184,6 +193,14 @@ class StorageController(wsgi.Controller):
                     constants.SyncStatus.SYNCED:
                 msg = 'sync task is running for %s' % storage['id']
                 raise exc.HTTPBadRequest(explanation=msg)
+            # Set all bits of sync_status to SYNCING and start sync tasks
+            storage[constants.DB.DEVICE_SYNC_STATUS] = utils.set_bits(
+                storage[constants.DB.DEVICE_SYNC_STATUS],
+                0,
+                len(constants.ResourceType) - 1,
+                constants.SyncStatus.SYNCING)
+            db.storage_update(ctxt, storage['id'], storage)
+
             for subclass in task.StorageResourceTask.__subclasses__():
                 self.task_rpcapi.sync_storage_resource(
                     ctxt,

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -157,7 +157,6 @@ class StorageController(wsgi.Controller):
 
         for storage in storages:
             lock = coordination.Lock(storage['id'])
-            task_is_running = False
             with lock:
                 tmp_storage = db.storage_get(ctxt, storage['id'])
                 if tmp_storage[constants.DB.DEVICE_SYNC_STATUS] != \

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -145,8 +145,7 @@ class StorageController(wsgi.Controller):
             self.task_rpcapi.sync_storage_resource(
                 ctxt,
                 storage['id'],
-                subclass.__module__ + '.' + subclass.__name__
-            )
+                subclass.__module__ + '.' + subclass.__name__)
 
     def _storage_exist(self, context, access_info):
         access_info_dict = copy.deepcopy(access_info)

--- a/dolphin/api/views/storages.py
+++ b/dolphin/api/views/storages.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import copy
 
+from dolphin.common import constants
+
 
 def build_storages(storages):
     # Build list of storages
@@ -23,4 +25,8 @@ def build_storages(storages):
 
 def build_storage(storage):
     view = copy.deepcopy(storage)
+    if view[constants.DB.DEVICE_SYNC_STATUS] == constants.SyncStatus.SYNCED:
+        view[constants.DB.DEVICE_SYNC_STATUS] = 'SYNCED'
+    else:
+        view[constants.DB.DEVICE_SYNC_STATUS] = 'SYNCING'
     return dict(view)

--- a/dolphin/common/constants.py
+++ b/dolphin/common/constants.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from enum import IntEnum
 
 # The maximum value a signed INT type may have
 DB_MAX_INT = 0x7FFFFFFF
@@ -48,3 +49,21 @@ class StorageType(object):
     FILE = 'file'
 
     ALL = (BLOCK, FILE)
+
+
+class ResourceType(IntEnum):
+    STORAGE_DEVICE = 0
+    POOL = 1
+    VOLUME = 2
+    ACCESS_INFO = 3
+    DISK = 4
+    ALERT_SOURCE = 5
+
+
+class SyncStatus(IntEnum):
+    SYNCED = 0
+    SYNCING = 1
+
+
+class DB(object):
+    DEVICE_SYNC_STATUS = 'sync_status'

--- a/dolphin/common/constants.py
+++ b/dolphin/common/constants.py
@@ -55,9 +55,6 @@ class ResourceType(IntEnum):
     STORAGE_DEVICE = 0
     POOL = 1
     VOLUME = 2
-    ACCESS_INFO = 3
-    DISK = 4
-    ALERT_SOURCE = 5
 
 
 class SyncStatus(IntEnum):

--- a/dolphin/db/sqlalchemy/models.py
+++ b/dolphin/db/sqlalchemy/models.py
@@ -26,6 +26,8 @@ from oslo_db.sqlalchemy.types import JsonEncodedDict
 from sqlalchemy import Column, Integer, String, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 
+from dolphin.common import constants
+
 CONF = cfg.CONF
 BASE = declarative_base()
 
@@ -75,6 +77,7 @@ class Storage(BASE, DolphinBase):
     total_capacity = Column(Integer)
     used_capacity = Column(Integer)
     free_capacity = Column(Integer)
+    sync_status = Column(Integer, default=constants.SyncStatus.SYNCED)
 
 
 class Volume(BASE, DolphinBase):

--- a/dolphin/task_manager/manager.py
+++ b/dolphin/task_manager/manager.py
@@ -82,4 +82,4 @@ class TaskManager(manager.Manager):
         LOG.info('Remove storage device in memory for storage id:{0}'
                  .format(storage_id))
         drivers = driver_manager.DriverManager()
-        drivers.remove_driver(context, storage_id)
+        drivers.remove_driver(storage_id)

--- a/dolphin/tests/unit/test_utils.py
+++ b/dolphin/tests/unit/test_utils.py
@@ -2,5 +2,12 @@ from dolphin import utils
 
 
 def test_set_bit():
-    assert 128 == utils.set_bit(0, 7, 1)
-    assert 127 == utils.set_bit(255, 7, 0)
+    assert 0b10000000 == utils.set_bit(0, 7, 1)
+    assert 0b01111111 == utils.set_bit(0b11111111, 7, 0)
+
+
+def test_set_bits():
+    assert 0b1011101 == utils.set_bits(0b1000001, 2, 4, 1)
+    assert 0b1000001 == utils.set_bits(0b1011101, 2, 4, 0)
+    assert 0b1111 == utils.set_bits(0, 0, 3, 1)
+    assert 0 == utils.set_bits(0b1111, 0, 3, 0)

--- a/dolphin/tests/unit/test_utils.py
+++ b/dolphin/tests/unit/test_utils.py
@@ -1,0 +1,6 @@
+from dolphin import utils
+
+
+def test_set_bit():
+    assert 128 == utils.set_bit(0, 7, 1)
+    assert 127 == utils.set_bit(255, 7, 0)

--- a/dolphin/utils.py
+++ b/dolphin/utils.py
@@ -682,3 +682,11 @@ class Singleton(type):
                     cls._instances[cls] = super(Singleton,
                                                 cls).__call__(*args, **kwargs)
         return cls._instances[cls]
+
+
+def set_bit(source, index, value):
+    mask = 1 << index
+    source &= ~mask
+    if value:
+        source |= mask
+    return source

--- a/dolphin/utils.py
+++ b/dolphin/utils.py
@@ -690,3 +690,16 @@ def set_bit(source, index, value):
     if value:
         source |= mask
     return source
+
+
+def set_bits(source, start, end, value):
+    """
+    Set the bits from start to end([start, end]) for source to value
+    """
+    mask = 0
+    for index in range(start, end + 1):
+        mask = set_bit(mask, index, 1)
+    source &= ~mask
+    if value:
+        source |= mask
+    return source


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add sync status to avoid two sync tasks for the same device are running at the same time.
For a storage device, add a int(named _sync_status_) to indicate the sync status, each bit of this int indicates a resource.
When a sync task for a resource is running for a device, set the special bit of _sync_status_ of this device to 1, and when sync is done, set the special bit back to 0.
When received request to sync resource of a device, check if all the bit of _sync_status_ is 0(means no sync task is running for this device), if not, this request would not be handled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
For 'sync' api, if sync_status is not 0, raise a exception.
For 'sync_all' api, if sync_status of a device is not 0, skip this device and handle the next device.
```
Test case:
```
|-----------------------------------------------------------------------------------------------------|-----------------------------------------------|
| Test case                                     | Expected behavior for sync                          | Expected behavior for sync_all                |
|-----------------------------------------------------------------------------------------------------|-----------------------------------------------|
| No sync task is running                       | New sync task should run normally                   | New sync tasks should run normally            |
|-----------------------------------------------------------------------------------------------------------------------------------------------------|
| One of the sync task is running for a device  | New sync task should not run and raise an exception | New sync task of that device should not run,  |
|                                               |                                                     | but other devices' tasks should run normally  |
|-----------------------------------------------------------------------------------------------------------------------------------------------------|
| All of the sync task is running for a device  | New sync task should not run and raise an exception | New sync task of that device should not run,  |
|                                               |                                                     | but other devices' tasks should run normally  |
|-----------------------------------------------------------------------------------------------------------------------------------------------------|
```
