### PR TITLE
Support soft delete for storage device

### DIFF
--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -16,7 +16,6 @@ import copy
 
 from oslo_log import log
 
-from dolphin import context
 from dolphin import coordination
 from dolphin import db
 from dolphin import utils

--- a/dolphin/api/v1/storages.py
+++ b/dolphin/api/v1/storages.py
@@ -58,7 +58,7 @@ class StorageController(wsgi.Controller):
         api_utils.remove_invalid_options(ctxt, query_params,
                                          self._get_storages_search_options())
 
-        storages = db.storage_get_all(context, marker, limit, sort_keys,
+        storages = db.storage_get_all(ctxt, marker, limit, sort_keys,
                                       sort_dirs, query_params, offset)
         return storage_view.build_storages(storages)
 

--- a/dolphin/common/constants.py
+++ b/dolphin/common/constants.py
@@ -54,7 +54,7 @@ class StorageType(object):
 class ResourceType(IntEnum):
     STORAGE_DEVICE = 0
     STORAGE_POOL = 1
-    VOLUME = 2
+    STORAGE_VOLUME = 2
 
 
 class SyncStatus(IntEnum):

--- a/dolphin/db/sqlalchemy/api.py
+++ b/dolphin/db/sqlalchemy/api.py
@@ -274,7 +274,15 @@ def _storage_get(context, storage_id, session=None):
 
 
 def _storage_get_query(context, session=None):
-    return model_query(context, models.Storage, session=session)
+    read_deleted = context.read_deleted
+    kwargs = dict()
+
+    if read_deleted in ('no', 'n', False):
+        kwargs['deleted'] = False
+    elif read_deleted in ('yes', 'y', True):
+        kwargs['deleted'] = True
+
+    return model_query(context, models.Storage, session=session, **kwargs)
 
 
 def storage_get_all(context, marker=None, limit=None, sort_keys=None,
@@ -304,7 +312,7 @@ def _process_storage_info_filters(query, filters):
 
 def storage_delete(context, storage_id):
     """Delete a storage device."""
-    _storage_get_query(context).filter_by(id=storage_id).delete()
+    _storage_get_query(context).filter_by(id=storage_id).soft_delete()
 
 
 def _volume_get_query(context, session=None):

--- a/dolphin/db/sqlalchemy/models.py
+++ b/dolphin/db/sqlalchemy/models.py
@@ -59,7 +59,7 @@ class AccessInfo(BASE, DolphinBase):
     extra_attributes = Column(JsonEncodedDict)
 
 
-class Storage(BASE, DolphinBase):
+class Storage(BASE, DolphinBase, models.SoftDeleteMixin):
     """Represents a storage object."""
 
     __tablename__ = 'storages'

--- a/dolphin/task_manager/tasks/task.py
+++ b/dolphin/task_manager/tasks/task.py
@@ -60,15 +60,16 @@ def check_deleted(resource_type):
         call_args = inspect.getcallargs(func, *args, **kwargs)
         self = call_args['self']
         ret = func(*args, **kwargs)
+        # When context.read_deleted = 'yes', db.storage_get would
+        # only get the storage whose 'deleted' tag is not default value
         self.context.read_deleted = 'yes'
         try:
-            storage = db.storage_get(self.context, self.storage_id)
+            db.storage_get(self.context, self.storage_id)
         except exception.StorageNotFound:
-            LOG.warn('Storage %s not found when checking deleted'
-                     % self.storage_id)
+            LOG.debug('Storage %s not found when checking deleted'
+                      % self.storage_id)
         else:
-            if storage['deleted'] != 0:
-                self.remove()
+            self.remove()
         return ret
 
     return _check_deleted

--- a/dolphin/task_manager/tasks/task.py
+++ b/dolphin/task_manager/tasks/task.py
@@ -40,7 +40,8 @@ def set_synced_after(resource_type):
             try:
                 storage = db.storage_get(self.context, self.storage_id)
             except exception.StorageNotFound:
-                LOG.warn('Storage %s not found when set synced' % self.storage_id)
+                LOG.warn('Storage %s not found when set synced'
+                         % self.storage_id)
             else:
                 storage[constants.DB.DEVICE_SYNC_STATUS] = utils.set_bit(
                     storage[constants.DB.DEVICE_SYNC_STATUS],
@@ -63,7 +64,8 @@ def check_deleted(resource_type):
         try:
             storage = db.storage_get(self.context, self.storage_id)
         except exception.StorageNotFound:
-            LOG.warn('Storage %s not found when checking deleted' % self.storage_id)
+            LOG.warn('Storage %s not found when checking deleted'
+                     % self.storage_id)
         else:
             if storage['deleted'] != 0:
                 self.remove()

--- a/dolphin/task_manager/tasks/task.py
+++ b/dolphin/task_manager/tasks/task.py
@@ -53,7 +53,7 @@ def set_synced_after(resource_type):
     return _set_synced_after
 
 
-def check_deleted(resource_type):
+def check_deleted():
 
     @decorator.decorator
     def _check_deleted(func, *args, **kwargs):
@@ -113,7 +113,7 @@ class StorageDeviceTask(StorageResourceTask):
     def __init__(self, context, storage_id):
         super(StorageDeviceTask, self).__init__(context, storage_id)
 
-    @check_deleted(constants.ResourceType.STORAGE_DEVICE)
+    @check_deleted()
     @set_synced_after(constants.ResourceType.STORAGE_DEVICE)
     def sync(self):
         """
@@ -150,8 +150,8 @@ class StoragePoolTask(StorageResourceTask):
     def __init__(self, context, storage_id):
         super(StoragePoolTask, self).__init__(context, storage_id)
 
-    @check_deleted(constants.ResourceType.POOL)
-    @set_synced_after(constants.ResourceType.POOL)
+    @check_deleted()
+    @set_synced_after(constants.ResourceType.STORAGE_POOL)
     def sync(self):
         """
         :return:
@@ -194,8 +194,8 @@ class StorageVolumeTask(StorageResourceTask):
     def __init__(self, context, storage_id):
         super(StorageVolumeTask, self).__init__(context, storage_id)
 
-    @check_deleted(constants.ResourceType.VOLUME)
-    @set_synced_after(constants.ResourceType.VOLUME)
+    @check_deleted()
+    @set_synced_after(constants.ResourceType.STORAGE_VOLUME)
     def sync(self):
         """
         :return:

--- a/dolphin/task_manager/tasks/task.py
+++ b/dolphin/task_manager/tasks/task.py
@@ -31,10 +31,10 @@ LOG = log.getLogger(__name__)
 def set_synced_after(resource_type):
 
     @decorator.decorator
-    def _set_synced_after(f, *a, **k):
-        call_args = inspect.getcallargs(f, *a, **k)
+    def _set_synced_after(func, *args, **kwargs):
+        call_args = inspect.getcallargs(func, *args, **kwargs)
         self = call_args['self']
-        ret = f(*a, **k)
+        ret = func(*args, **kwargs)
         lock = coordination.Lock(self.storage_id)
         with lock:
             try:
@@ -56,10 +56,10 @@ def set_synced_after(resource_type):
 def check_deleted(resource_type):
 
     @decorator.decorator
-    def _check_deleted(f, *a, **k):
-        call_args = inspect.getcallargs(f, *a, **k)
+    def _check_deleted(func, *args, **kwargs):
+        call_args = inspect.getcallargs(func, *args, **kwargs)
         self = call_args['self']
-        ret = f(*a, **k)
+        ret = func(*args, **kwargs)
         self.context.read_deleted = 'yes'
         try:
             storage = db.storage_get(self.context, self.storage_id)

--- a/dolphin/tests/unit/db/test_db_api.py
+++ b/dolphin/tests/unit/db/test_db_api.py
@@ -5,6 +5,8 @@ from dolphin import test
 from dolphin.db import api as db_api
 from dolphin.db.sqlalchemy import api, models
 
+ctxt = context.get_admin_context()
+
 
 class TestSIMDBAPI(test.TestCase):
 
@@ -23,7 +25,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_storage = {}
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_storage
-        result = db_api.storage_get(context,
+        result = db_api.storage_get(ctxt,
                                     'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')
         assert len(result) == 0
 
@@ -32,7 +34,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_storage = models.Storage()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_storage
-        result = db_api.storage_update(context,
+        result = db_api.storage_update(ctxt,
                                        'c5c91c98-91aa-40e6-85ac-37a1d3b32bda',
                                        fake_storage)
         assert len(result) == 0
@@ -42,7 +44,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_storage = models.Storage()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_storage
-        result = db_api.storage_delete(context,
+        result = db_api.storage_delete(ctxt,
                                        'c5c91c98-91aa-40e6-85ac-37a1d3b32bda')
         assert result is None
 
@@ -51,7 +53,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_storage = models.Storage()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_storage
-        result = db_api.storage_create(context, fake_storage)
+        result = db_api.storage_create(ctxt, fake_storage)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -59,32 +61,32 @@ class TestSIMDBAPI(test.TestCase):
         fake_storage = []
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_storage
-        result = db_api.storage_get_all(context)
+        result = db_api.storage_get_all(ctxt)
         assert len(result) == 0
 
         mock_session.return_value.__enter__.return_value.query = fake_storage
-        result = db_api.storage_get_all(context, filters={'status': 'Normal'})
+        result = db_api.storage_get_all(ctxt, filters={'status': 'Normal'})
         assert len(result) == 0
 
-        result = db_api.storage_get_all(context, limit=1)
+        result = db_api.storage_get_all(ctxt, limit=1)
         assert len(result) == 0
 
-        result = db_api.storage_get_all(context, offset=3)
+        result = db_api.storage_get_all(ctxt, offset=3)
         assert len(result) == 0
 
-        result = db_api.storage_get_all(context, sort_dirs=['desc'],
+        result = db_api.storage_get_all(ctxt, sort_dirs=['desc'],
                                         sort_keys=['name'])
         assert len(result) == 0
 
         self.assertRaises(exception.InvalidInput, api.storage_get_all,
-                          context, sort_dirs=['desc', 'asc'],
+                          ctxt, sort_dirs=['desc', 'asc'],
                           sort_keys=['name'])
 
         self.assertRaises(exception.InvalidInput, api.storage_get_all,
-                          context, sort_dirs=['desc_err'],
+                          ctxt, sort_dirs=['desc_err'],
                           sort_keys=['name'])
 
-        result = db_api.storage_get_all(context, sort_dirs=['desc'],
+        result = db_api.storage_get_all(ctxt, sort_dirs=['desc'],
                                         sort_keys=['name', 'id'])
         assert len(result) == 0
 
@@ -93,7 +95,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_pool = {}
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_pool
-        result = db_api.pool_get(context,
+        result = db_api.pool_get(ctxt,
                                  'c5c91c98-91aa-40e6-85ac-37a1d3b32bd')
         assert len(result) == 0
 
@@ -102,10 +104,10 @@ class TestSIMDBAPI(test.TestCase):
         fake_pool = []
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_pool
-        result = api.pool_get_all(context)
+        result = api.pool_get_all(ctxt)
         assert len(result) == 0
 
-        result = db_api.pool_get_all(context, filters={'status': 'Normal'})
+        result = db_api.pool_get_all(ctxt, filters={'status': 'Normal'})
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -113,7 +115,7 @@ class TestSIMDBAPI(test.TestCase):
         pools = [{'id': 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd'}]
         mock_session.return_value.__enter__.return_value.query.return_value \
             = pools
-        result = db_api.pools_update(context, pools)
+        result = db_api.pools_update(ctxt, pools)
         assert len(result) == 1
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -121,7 +123,7 @@ class TestSIMDBAPI(test.TestCase):
         values = {'id': 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd'}
         mock_session.return_value.__enter__.return_value.query.return_value \
             = values
-        result = db_api.pool_update(context,
+        result = db_api.pool_update(ctxt,
                                     'c5c91c98-91aa-40e6-85ac-37a1d3b32bd',
                                     values)
         assert len(result) == 0
@@ -131,7 +133,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_pools = [models.Pool().id]
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_pools
-        result = db_api.pools_delete(context, fake_pools)
+        result = db_api.pools_delete(ctxt, fake_pools)
         assert result is None
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -139,7 +141,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_pools = [models.Pool()]
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_pools
-        result = db_api.pools_create(context, fake_pools)
+        result = db_api.pools_create(ctxt, fake_pools)
         assert len(result) == 1
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -147,7 +149,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_pool = models.Pool()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_pool
-        result = db_api.pool_create(context, fake_pool)
+        result = db_api.pool_create(ctxt, fake_pool)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -155,7 +157,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_volume = {}
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_volume
-        result = db_api.volume_get(context,
+        result = db_api.volume_get(ctxt,
                                    'c5c91c98-91aa-40e6-85ac-37a1d3b32bd')
         assert len(result) == 0
 
@@ -164,7 +166,7 @@ class TestSIMDBAPI(test.TestCase):
         volumes = [{'id': 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd'}]
         mock_session.return_value.__enter__.return_value.query.return_value \
             = volumes
-        result = db_api.volumes_update(context, volumes)
+        result = db_api.volumes_update(ctxt, volumes)
         assert result is None
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -172,7 +174,7 @@ class TestSIMDBAPI(test.TestCase):
         volumes = [{'id': 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd'}]
         mock_session.return_value.__enter__.return_value.query.return_value \
             = volumes
-        result = db_api.volume_update(context,
+        result = db_api.volume_update(ctxt,
                                       'c5c91c98-91aa-40e6-85ac-37a1d3b32bd',
                                       volumes)
         assert len(result) == 0
@@ -182,7 +184,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_volume = ['c5c91c98-91aa-40e6-85ac-37a1d3b32bd']
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_volume
-        result = db_api.volumes_delete(context, fake_volume)
+        result = db_api.volumes_delete(ctxt, fake_volume)
         assert result is None
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -190,7 +192,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_volume = [models.Volume()]
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_volume
-        result = db_api.volumes_create(context, fake_volume)
+        result = db_api.volumes_create(ctxt, fake_volume)
         assert len(result) == 1
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -198,7 +200,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_volume = models.Volume()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_volume
-        result = db_api.volume_create(context, fake_volume)
+        result = db_api.volume_create(ctxt, fake_volume)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -206,10 +208,10 @@ class TestSIMDBAPI(test.TestCase):
         fake_volume = []
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_volume
-        result = db_api.volume_get_all(context)
+        result = db_api.volume_get_all(ctxt)
         assert len(result) == 0
 
-        result = db_api.volume_get_all(context, filters={'status': 'Normal'})
+        result = db_api.volume_get_all(ctxt, filters={'status': 'Normal'})
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -217,7 +219,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_access_info = []
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_access_info
-        result = db_api.access_info_get_all(context)
+        result = db_api.access_info_get_all(ctxt)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -225,7 +227,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_access_info = models.AccessInfo()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_access_info
-        result = db_api.access_info_get(context,
+        result = db_api.access_info_get(ctxt,
                                         'c5c91c98-91aa-40e6-85ac-37a1d3b32bd')
         assert len(result) == 0
 
@@ -234,7 +236,7 @@ class TestSIMDBAPI(test.TestCase):
         fake_access_info = models.AccessInfo()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_access_info
-        result = db_api.access_info_create(context, fake_access_info)
+        result = db_api.access_info_create(ctxt, fake_access_info)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -243,7 +245,7 @@ class TestSIMDBAPI(test.TestCase):
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_access_info
         result = db_api.access_info_update(
-            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd', fake_access_info)
+            ctxt, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd', fake_access_info)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -251,10 +253,10 @@ class TestSIMDBAPI(test.TestCase):
         fake_alert_source = []
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_alert_source
-        result = db_api.alert_source_get_all(context)
+        result = db_api.alert_source_get_all(ctxt)
         assert len(result) == 0
 
-        result = db_api.alert_source_get_all(context,
+        result = db_api.alert_source_get_all(ctxt,
                                              filters={'status': 'Normal'})
         assert len(result) == 0
 
@@ -264,7 +266,7 @@ class TestSIMDBAPI(test.TestCase):
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_alert_source
         result = db_api.alert_source_update(
-            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd', fake_alert_source)
+            ctxt, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd', fake_alert_source)
         assert len(result) == 0
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -273,7 +275,7 @@ class TestSIMDBAPI(test.TestCase):
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_alert_source
         result = db_api.alert_source_delete(
-            context, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd')
+            ctxt, 'c5c91c98-91aa-40e6-85ac-37a1d3b32bd')
         assert result is None
 
     @mock.patch('dolphin.db.sqlalchemy.api.get_session')
@@ -281,5 +283,5 @@ class TestSIMDBAPI(test.TestCase):
         fake_alert_source = models.AlertSource()
         mock_session.return_value.__enter__.return_value.query.return_value \
             = fake_alert_source
-        result = db_api.alert_source_create(context, fake_alert_source)
+        result = db_api.alert_source_create(ctxt, fake_alert_source)
         assert len(result) == 0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Support soft delete for storage device, so when we delete storage device, the data in db would not be delete exactlly, but set the key 'deleted' to a specific value.
2. When syncing task of a device is done, check the 'deleted' tag of that device, if it was not '0', delete all the data that synced just now.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Inherit from `oslo_db.sqlalchemy.models.SoftDeleteMixin` to implement the soft delete.
The source code of `oslo_db.sqlalchemy.models.SoftDeleteMixin`:
```python
class SoftDeleteMixin(object):
    deleted_at = Column(DateTime)
    deleted = Column(types.SoftDeleteInteger, default=0)

    def soft_delete(self, session):
        """Mark this object as deleted."""
        self.deleted = self.id
        self.deleted_at = timeutils.utcnow()
        self.save(session=session)
```
When we need to delete a storage device, we would call `soft_delete` instead of `delete`.