### PR TITLE
Add common setup/teardown with unit test framework

### DIFF
--- a/dolphin/test.py
+++ b/dolphin/test.py
@@ -1,0 +1,344 @@
+# Copyright 2020 The SODA Authors.
+# Copyright 2010 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Base classes for our unit tests.
+
+Allows overriding of flags for use of fakes, and some black magic for
+inline callbacks.
+
+"""
+
+import fixtures
+from unittest import mock
+from oslo_concurrency import lockutils
+from oslo_config import cfg
+from oslo_config import fixture as config_fixture
+import oslo_messaging
+from oslo_messaging import conffixture as messaging_conffixture
+from oslo_utils import uuidutils
+import oslotest.base as base_test
+
+from dolphin import coordination
+from dolphin.db.sqlalchemy import api as db_api
+from dolphin.db.sqlalchemy import models as db_models
+from dolphin import rpc
+from dolphin import service
+from dolphin.tests.unit import conf_fixture, fake_notifier
+
+test_opts = [
+    cfg.StrOpt('sqlite_db',
+               default='dolphin.sqlite',
+               help='The filename to use with sqlite.'),
+]
+
+CONF = cfg.CONF
+CONF.register_opts(test_opts)
+
+_DB_CACHE = None
+
+
+class Database(fixtures.Fixture):
+
+    def __init__(self, db_session, sql_connection):
+        self.sql_connection = sql_connection
+        self.engine = db_session.get_engine()
+        self.engine.dispose()
+        conn = self.engine.connect()
+        db_models.BASE.metadata.create_all(self.engine)
+        self._DB = "".join(line for line in conn.connection.iterdump())
+        self.engine.dispose()
+
+    def setUp(self):
+        super(Database, self).setUp()
+        conn = self.engine.connect()
+        conn.connection.executescript(self._DB)
+        self.addCleanup(self.engine.dispose)
+
+
+class TestCase(base_test.BaseTestCase):
+    """Test case base class for all unit tests."""
+
+    def setUp(self):
+        """Run before each test method to initialize test environment."""
+        super(TestCase, self).setUp()
+
+        conf_fixture.set_defaults(CONF)
+        CONF([], default_config_files=[])
+
+        global _DB_CACHE
+        if not _DB_CACHE:
+            _DB_CACHE = Database(
+                db_api,
+                sql_connection=CONF.database.connection)
+        self.useFixture(_DB_CACHE)
+
+        self.injected = []
+        self._services = []
+        # This will be cleaned up by the NestedTempfile fixture
+        lock_path = self.useFixture(fixtures.TempDir()).path
+        self.fixture = self.useFixture(config_fixture.Config(lockutils.CONF))
+        self.fixture.config(lock_path=lock_path, group='oslo_concurrency')
+        self.fixture.config(
+            disable_process_locking=True, group='oslo_concurrency')
+
+        rpc.add_extra_exmods('dolphin.tests')
+        self.addCleanup(rpc.clear_extra_exmods)
+        self.addCleanup(rpc.cleanup)
+
+        self.messaging_conf = messaging_conffixture.ConfFixture(CONF)
+        self.messaging_conf.transport_url = 'fake:/'
+        self.messaging_conf.response_timeout = 15
+        self.useFixture(self.messaging_conf)
+
+        oslo_messaging.get_notification_transport(CONF)
+        self.override_config('driver', ['test'],
+                             group='oslo_messaging_notifications')
+
+        rpc.init(CONF)
+
+        fake_notifier.stub_notifier(self)
+
+        # Locks must be cleaned up after tests
+        CONF.set_override('backend_url', 'file://' + lock_path,
+                          group='coordination')
+        coordination.LOCK_COORDINATOR.start()
+        self.addCleanup(coordination.LOCK_COORDINATOR.stop)
+
+    def tearDown(self):
+        """Runs after each test method to tear down test environment."""
+        super(TestCase, self).tearDown()
+        # Reset any overridden flags
+        CONF.reset()
+
+        # Stop any timers
+        for x in self.injected:
+            try:
+                x.stop()
+            except AssertionError:
+                pass
+
+        # Kill any services
+        for x in self._services:
+            try:
+                x.kill()
+            except Exception:
+                pass
+
+        # Delete attributes that don't start with _ so they don't pin
+        # memory around unnecessarily for the duration of the test
+        # suite
+        for key in [k for k in self.__dict__.keys() if k[0] != '_']:
+            del self.__dict__[key]
+
+    def flags(self, **kw):
+        """Override flag variables for a test."""
+        for k, v in kw.items():
+            CONF.set_override(k, v)
+
+    def start_service(self, name, host=None, **kwargs):
+        host = host and host or uuidutils.generate_uuid()
+        kwargs.setdefault('host', host)
+        kwargs.setdefault('binary', 'dolphin-%s' % name)
+        svc = service.Service.create(**kwargs)
+        svc.start()
+        self._services.append(svc)
+        return svc
+
+    def mock_object(self, obj, attr_name, new_attr=None, **kwargs):
+        """Use python mock to mock an object attribute
+
+        Mocks the specified objects attribute with the given value.
+        Automatically performs 'addCleanup' for the mock.
+
+        """
+        if not new_attr:
+            new_attr = mock.Mock()
+        patcher = mock.patch.object(obj, attr_name, new_attr, **kwargs)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return new_attr
+
+    def mock_class(self, class_name, new_val=None, **kwargs):
+        """Use python mock to mock a class
+
+        Mocks the specified objects attribute with the given value.
+        Automatically performs 'addCleanup' for the mock.
+
+        """
+        if not new_val:
+            new_val = mock.Mock()
+        patcher = mock.patch(class_name, new_val, **kwargs)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return new_val
+
+    # Useful assertions
+    def assertDictMatch(self, d1, d2, approx_equal=False, tolerance=0.001):
+        """Assert two dicts are equivalent.
+
+        This is a 'deep' match in the sense that it handles nested
+        dictionaries appropriately.
+
+        NOTE:
+
+            If you don't care (or don't know) a given value, you can specify
+            the string DONTCARE as the value. This will cause that dict-item
+            to be skipped.
+
+        """
+        def raise_assertion(msg):
+            d1str = str(d1)
+            d2str = str(d2)
+            base_msg = ('Dictionaries do not match. %(msg)s d1: %(d1str)s '
+                        'd2: %(d2str)s' %
+                        {"msg": msg, "d1str": d1str, "d2str": d2str})
+            raise AssertionError(base_msg)
+
+        d1keys = set(d1.keys())
+        d2keys = set(d2.keys())
+        if d1keys != d2keys:
+            d1only = d1keys - d2keys
+            d2only = d2keys - d1keys
+            raise_assertion('Keys in d1 and not d2: %(d1only)s. '
+                            'Keys in d2 and not d1: %(d2only)s' %
+                            {"d1only": d1only, "d2only": d2only})
+
+        for key in d1keys:
+            d1value = d1[key]
+            d2value = d2[key]
+            try:
+                error = abs(float(d1value) - float(d2value))
+                within_tolerance = error <= tolerance
+            except (ValueError, TypeError):
+                # If both values aren't convertible to float, just ignore
+                # ValueError if arg is a str, TypeError if it's something else
+                # (like None)
+                within_tolerance = False
+
+            if hasattr(d1value, 'keys') and hasattr(d2value, 'keys'):
+                self.assertDictMatch(d1value, d2value)
+            elif 'DONTCARE' in (d1value, d2value):
+                continue
+            elif approx_equal and within_tolerance:
+                continue
+            elif d1value != d2value:
+                raise_assertion("d1['%(key)s']=%(d1value)s != "
+                                "d2['%(key)s']=%(d2value)s" %
+                                {
+                                    "key": key,
+                                    "d1value": d1value,
+                                    "d2value": d2value
+                                })
+
+    def assertDictListMatch(self, L1, L2, approx_equal=False, tolerance=0.001):
+        """Assert a list of dicts are equivalent."""
+        def raise_assertion(msg):
+            L1str = str(L1)
+            L2str = str(L2)
+            base_msg = ('List of dictionaries do not match: %(msg)s '
+                        'L1: %(L1str)s L2: %(L2str)s' %
+                        {"msg": msg, "L1str": L1str, "L2str": L2str})
+            raise AssertionError(base_msg)
+
+        L1count = len(L1)
+        L2count = len(L2)
+        if L1count != L2count:
+            raise_assertion('Length mismatch: len(L1)=%(L1count)d != '
+                            'len(L2)=%(L2count)d' %
+                            {"L1count": L1count, "L2count": L2count})
+
+        for d1, d2 in zip(L1, L2):
+            self.assertDictMatch(d1, d2, approx_equal=approx_equal,
+                                 tolerance=tolerance)
+
+    def assertSubDictMatch(self, sub_dict, super_dict):
+        """Assert a sub_dict is subset of super_dict."""
+        self.assertTrue(set(sub_dict.keys()).issubset(set(super_dict.keys())))
+        for k, sub_value in sub_dict.items():
+            super_value = super_dict[k]
+            if isinstance(sub_value, dict):
+                self.assertSubDictMatch(sub_value, super_value)
+            elif 'DONTCARE' in (sub_value, super_value):
+                continue
+            else:
+                self.assertEqual(sub_value, super_value)
+
+    def assertIn(self, a, b, *args, **kwargs):
+        """Python < v2.7 compatibility.  Assert 'a' in 'b'."""
+        try:
+            f = super(TestCase, self).assertIn
+        except AttributeError:
+            self.assertTrue(a in b, *args, **kwargs)
+        else:
+            f(a, b, *args, **kwargs)
+
+    def assertNotIn(self, a, b, *args, **kwargs):
+        """Python < v2.7 compatibility.  Assert 'a' NOT in 'b'."""
+        try:
+            f = super(TestCase, self).assertNotIn
+        except AttributeError:
+            self.assertFalse(a in b, *args, **kwargs)
+        else:
+            f(a, b, *args, **kwargs)
+
+    def assertIsInstance(self, a, b, *args, **kwargs):
+        """Python < v2.7 compatibility."""
+        try:
+            f = super(TestCase, self).assertIsInstance
+        except AttributeError:
+            self.assertIsInstance(a, b)
+        else:
+            f(a, b, *args, **kwargs)
+
+    def assertIsNone(self, a, *args, **kwargs):
+        """Python < v2.7 compatibility."""
+        try:
+            f = super(TestCase, self).assertIsNone
+        except AttributeError:
+            self.assertTrue(a is None)
+        else:
+            f(a, *args, **kwargs)
+
+    def _dict_from_object(self, obj, ignored_keys):
+        if ignored_keys is None:
+            ignored_keys = []
+        return {k: v for k, v in obj.items()
+                if k not in ignored_keys}
+
+    def _assertEqualListsOfObjects(self, objs1, objs2, ignored_keys=None):
+        obj_to_dict = lambda o: (  # noqa: E731
+            self._dict_from_object(o, ignored_keys))
+        sort_key = lambda d: [d[k] for k in sorted(d)]  # noqa: E731
+        conv_and_sort = lambda obj: (  # noqa: E731
+            sorted(map(obj_to_dict, obj), key=sort_key))
+
+        self.assertEqual(conv_and_sort(objs1), conv_and_sort(objs2))
+
+    def assert_notify_called(self, mock_notify, calls):
+        for i in range(0, len(calls)):
+            mock_call = mock_notify.call_args_list[i]
+            call = calls[i]
+
+            posargs = mock_call[0]
+
+            self.assertEqual(call[0], posargs[0])
+            self.assertEqual(call[1], posargs[2])
+
+    def override_config(self, name, override, group=None):
+        """Cleanly override CONF variables."""
+        CONF.set_override(name, override, group)
+        self.addCleanup(CONF.clear_override, name, group)

--- a/dolphin/tests/unit/api/fakes.py
+++ b/dolphin/tests/unit/api/fakes.py
@@ -1,0 +1,40 @@
+# Copyright 2020 The SODA Authors.
+# Copyright 2010 OpenStack LLC.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import webob.dec
+import webob.request
+
+from dolphin import context
+from dolphin.api.common import wsgi as os_wsgi
+from dolphin.common import config  # noqa
+
+
+@webob.dec.wsgify
+def fake_wsgi(self, req):
+    return self.application
+
+
+class HTTPRequest(os_wsgi.Request):
+
+    @classmethod
+    def blank(cls, *args, **kwargs):
+        if not kwargs.get('base_url'):
+            kwargs['base_url'] = 'http://localhost/v1'
+        use_admin_context = kwargs.pop('use_admin_context', False)
+        out = os_wsgi.Request.blank(*args, **kwargs)
+        out.environ['dolphin.context'] = context.RequestContext(
+            is_admin=use_admin_context)
+        return out

--- a/dolphin/tests/unit/api/v1/test_storages.py
+++ b/dolphin/tests/unit/api/v1/test_storages.py
@@ -1,3 +1,17 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest import mock
 
 from dolphin import db

--- a/dolphin/tests/unit/conf_fixture.py
+++ b/dolphin/tests/unit/conf_fixture.py
@@ -1,0 +1,47 @@
+# Copyright 2020 The SODA Authors.
+# Copyright 2010 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+
+from oslo_service import wsgi
+
+from dolphin.common import config
+
+CONF = config.CONF
+
+
+def set_defaults(conf):
+    _safe_set_of_opts(conf, 'verbose', True)
+    _safe_set_of_opts(conf, 'state_path', os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     '..',
+                     '..')))
+    _safe_set_of_opts(conf, 'connection', "sqlite://", group='database')
+    _safe_set_of_opts(conf, 'sqlite_synchronous', False)
+    _API_PASTE_PATH = os.path.abspath(
+        os.path.join(CONF.state_path,
+                     'etc/dolphin/api-paste.ini'))
+    wsgi.register_opts(conf)
+    _safe_set_of_opts(conf, 'api_paste_config', _API_PASTE_PATH)
+
+
+def _safe_set_of_opts(conf, *args, **kwargs):
+    try:
+        conf.set_default(*args, **kwargs)
+    except config.cfg.NoSuchOptError:
+        # Assumed that opt is not imported and not used
+        pass

--- a/dolphin/tests/unit/db/test_db_api.py
+++ b/dolphin/tests/unit/db/test_db_api.py
@@ -1,12 +1,14 @@
-import unittest
 from unittest import mock
-from dolphin.db.sqlalchemy import api, models
-from dolphin.db import api as db_api
+
 from dolphin import context, exception
+from dolphin import test
+from dolphin.db import api as db_api
+from dolphin.db.sqlalchemy import api, models
 
 
-class TestSIMDBAPI(unittest.TestCase):
+class TestSIMDBAPI(test.TestCase):
 
+    @mock.patch('sqlalchemy.create_engine', mock.Mock())
     def test_register_db(self):
         db_api.register_db()
 

--- a/dolphin/tests/unit/fake_notifier.py
+++ b/dolphin/tests/unit/fake_notifier.py
@@ -1,0 +1,71 @@
+# Copyright 2014 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import collections
+import functools
+
+import oslo_messaging as messaging
+from oslo_serialization import jsonutils
+
+from dolphin import rpc
+
+NOTIFICATIONS = []
+
+
+def reset():
+    del NOTIFICATIONS[:]
+
+
+FakeMessage = collections.namedtuple(
+    'Message',
+    ['publisher_id', 'priority', 'event_type', 'payload'],
+)
+
+
+class FakeNotifier(object):
+
+    def __init__(self, transport, publisher_id=None, serializer=None):
+        self.transport = transport
+        self.publisher_id = publisher_id
+        for priority in ['debug', 'info', 'warn', 'error', 'critical']:
+            setattr(self, priority,
+                    functools.partial(self._notify, priority.upper()))
+        self._serializer = serializer or messaging.serializer.NoOpSerializer()
+
+    def prepare(self, publisher_id=None):
+        if publisher_id is None:
+            publisher_id = self.publisher_id
+        return self.__class__(self.transport, publisher_id, self._serializer)
+
+    def _notify(self, priority, ctxt, event_type, payload):
+        payload = self._serializer.serialize_entity(ctxt, payload)
+        # NOTE(sileht): simulate the kombu serializer
+        # this permit to raise an exception if something have not
+        # been serialized correctly
+        jsonutils.to_primitive(payload)
+        msg = dict(publisher_id=self.publisher_id,
+                   priority=priority,
+                   event_type=event_type,
+                   payload=payload)
+        NOTIFICATIONS.append(msg)
+
+
+def stub_notifier(testcase):
+    testcase.mock_object(messaging, 'Notifier', FakeNotifier)
+    if rpc.NOTIFIER:
+        serializer = getattr(rpc.NOTIFIER, '_serializer', None)
+        testcase.mock_object(rpc, 'NOTIFIER',
+                             FakeNotifier(rpc.NOTIFIER.transport,
+                                          rpc.NOTIFIER.publisher_id,
+                                          serializer=serializer))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-usefixtures = cache
-python_files = test_*.py __init__.py

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-pytest
-pytest-cov
-pytest-mock
-fixtures
-mock
+coverage!=4.4,>=4.0 # Apache-2.0
+ddt>=1.0.1 # MIT
+fixtures>=3.0.0 # Apache-2.0/BSD
+oslotest>=3.2.0 # Apache-2.0
+testtools>=2.2.0 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands =
-    py.test --cov=dolphin --cov-report=term-missing {posargs:dolphin}
+    coverage erase
+    coverage run -m unittest discover {posargs:dolphin/tests/unit}
+    coverage html -d htmlcov
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fix partially #141 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
(venv) D:\erik\workspace\dolphin>tox
py3 develop-inst-noop: D:\erik\workspace\dolphin
py3 installed: alembic==1.4.2,amqp==2.6.0,attrs==19.3.0,Babel==2.8.0,bcrypt==3.1.7,cachetools==4.1.0,certifi==2020.4.5.2,cffi==1.14.0,chardet==3.0.4,cliff==3.1.0,cmd2==0.8.1,cover
age==5.1,cryptography==2.9.2,ddt==1.4.1,debtcollector==2.1.0,decorator==4.4.2,dnspython==1.16.0,-e git+https://github.com/katurii/dolphin.git@7cb676c14c92328c6c2f1cd90ef8dcc8a46c1
f58#egg=dolphin,eventlet==0.25.2,extras==1.0.0,fasteners==0.15,fixtures==3.0.0,future==0.18.2,futurist==2.2.0,greenlet==0.4.16,idna==2.9,iso8601==0.1.12,Jinja2==2.11.2,jsonschema=
=3.2.0,kombu==4.6.10,linecache2==1.0.0,Mako==1.1.3,MarkupSafe==1.1.1,mock==4.0.2,monotonic==1.5,msgpack==1.0.0,netaddr==0.7.19,netifaces==0.10.9,oslo.concurrency==4.1.0,oslo.confi
g==8.1.0,oslo.context==3.1.0,oslo.db==8.2.0,oslo.i18n==5.0.0,oslo.log==4.2.1,oslo.messaging==12.2.0,oslo.middleware==4.1.0,oslo.rootwrap==6.1.0,oslo.serialization==3.2.0,oslo.serv
ice==2.2.0,oslo.utils==4.2.0,oslotest==4.3.0,paramiko==2.7.1,Paste==3.4.1,PasteDeploy==2.1.0,pbr==5.4.5,ply==3.11,prettytable==0.7.2,pyasn1==0.4.8,pycparser==2.20,pycryptodomex==3
.9.7,PyNaCl==1.4.0,pyparsing==2.4.7,pyperclip==1.8.0,pyreadline==2.1,pyrsistent==0.16.0,pysmi==0.3.4,pysnmp==4.4.12,python-dateutil==2.8.1,python-editor==1.0.4,python-mimeparse==1
.6.0,python-subunit==1.4.0,pytz==2020.1,PyU4V==3.1.7,PyYAML==5.3.1,redis==3.5.3,repoze.lru==0.7,requests==2.23.0,retrying==1.3.3,rfc3986==1.4.0,Routes==2.4.1,six==1.15.0,SQLAlchem
y==1.3.17,sqlalchemy-migrate==0.13.0,sqlparse==0.3.1,statsd==3.3.0,stestr==3.0.1,stevedore==2.0.0,Tempita==0.5.2,tenacity==6.2.0,testresources==2.0.1,testscenarios==0.5.0,testtool
s==2.4.0,tooz==2.5.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.25.9,vine==1.3.0,voluptuous==0.11.7,WebOb==1.8.6,wrapt==1.12.1,yappi==1.2.5
py3 run-test-pre: PYTHONHASHSEED='245'
py3 run-test: commands[0] | coverage erase
py3 run-test: commands[1] | coverage run -m unittest discover dolphin/tests/unit
d:\erik\workspace\dolphin\.tox\py3\lib\site-packages\oslo_db\sqlalchemy\enginefacade.py:1370: OsloDBDeprecationWarning: EngineFacade is deprecated; please use oslo_db.sqlalchemy.
enginefacade
  return cls(
D:\erik\workspace\dolphin\dolphin\context.py:57: DeprecationWarning: Using the 'user' argument is deprecated in version '2.18' and will be removed in version '3.0', please use th
e 'user_id' argument instead
  super(RequestContext, self).__init__(
d:\erik\workspace\dolphin\.tox\py3\lib\site-packages\debtcollector\renames.py:43: DeprecationWarning: Using the 'tenant' argument is deprecated in version '2.18' and will be remo
ved in version '3.0', please use the 'project_id' argument instead
  return wrapped(*args, **kwargs)
d:\erik\workspace\dolphin\.tox\py3\lib\site-packages\debtcollector\renames.py:43: DeprecationWarning: Using the 'domain' argument is deprecated in version '2.18' and will be remo
ved in version '3.0', please use the 'domain_id' argument instead
  return wrapped(*args, **kwargs)
d:\erik\workspace\dolphin\.tox\py3\lib\site-packages\debtcollector\renames.py:43: DeprecationWarning: Using the 'user_domain' argument is deprecated in version '2.18' and will be
 removed in version '3.0', please use the 'user_domain_id' argument instead
  return wrapped(*args, **kwargs)
d:\erik\workspace\dolphin\.tox\py3\lib\site-packages\debtcollector\renames.py:43: DeprecationWarning: Using the 'project_domain' argument is deprecated in version '2.18' and will
 be removed in version '3.0', please use the 'project_domain_id' argument instead
  return wrapped(*args, **kwargs)
D:\erik\workspace\dolphin\dolphin\context.py:72: DeprecationWarning: Property 'user' has moved to 'user_id' in version '2.6' and will be removed in version '3.0'
  self.user_id = self.user
D:\erik\workspace\dolphin\dolphin\context.py:73: DeprecationWarning: Property 'tenant' has moved to 'project_id' in version '2.6' and will be removed in version '3.0'
  self.project_id = self.tenant
..
----------------------------------------------------------------------
Ran 2 tests in 0.593s

OK
py3 run-test: commands[2] | coverage html -d htmlcov
pep8 develop-inst-noop: D:\erik\workspace\dolphin
pep8 installed: -e git+https://github.com/katurii/dolphin.git@7cb676c14c92328c6c2f1cd90ef8dcc8a46c1f58#egg=dolphin,flake8==3.8.2,mccabe==0.6.1,pycodestyle==2.6.0,pyflakes==2.2.0
pep8 run-test-pre: PYTHONHASHSEED='245'
pep8 run-test: commands[0] | flake8 dolphin
____________________________________________________________________________________ summary _____________________________________________________________________________________
  py3: commands succeeded
  pep8: commands succeeded
  congratulations :)

```
