### PR TITLE
Add configs for Tooz

### DIFF
--- a/dolphin/coordination.py
+++ b/dolphin/coordination.py
@@ -30,7 +30,7 @@ LOG = log.getLogger(__name__)
 
 coordination_opts = [
     cfg.StrOpt('backend_url',
-               default='',
+               default='redis://127.0.0.1:6379',
                help='The back end URL to use for distributed coordination.'),
     cfg.StrOpt('backend_type',
                default='redis',
@@ -83,25 +83,25 @@ class Coordinator(object):
 
         # NOTE(gouthamr): Tooz expects member_id as a byte string.
         member_id = (self.prefix + self.agent_id).encode('ascii')
-        if cfg.CONF.coordination.backend_password:
+        if CONF.coordination.backend_password:
             # If password is needed, the password should be
             # set in config file with cipher text
             # And in this scenario, these are also needed for backend:
             # {backend_type}://[{user}]:{password}@{ip}:{port}.
             plaintext_password = cryptor.decode(
-                cfg.CONF.coordination.backend_password).decode('utf-8')
+                CONF.coordination.backend_password).decode('utf-8')
             backend_url = '{backend_type}://{user}:{password}@{ip}:{port}'\
-                .format(backend_type=cfg.CONF.coordination.backend_type,
-                        user=cfg.CONF.coordination.backend_user,
+                .format(backend_type=CONF.coordination.backend_type,
+                        user=CONF.coordination.backend_user,
                         password=plaintext_password,
-                        ip=cfg.CONF.coordination.backend_ip,
-                        port=cfg.CONF.coordination.backend_port)
+                        ip=CONF.coordination.backend_ip,
+                        port=CONF.coordination.backend_port)
             CONF.set_override('backend_url', backend_url,
                               group='coordination')
 
         self.coordinator = coordination.get_coordinator(
             CONF.coordination.backend_url, member_id,
-            timeout=cfg.CONF.coordination.expiration)
+            timeout=CONF.coordination.expiration)
         self.coordinator.start(start_heart=True)
         self.started = True
 

--- a/dolphin/coordination.py
+++ b/dolphin/coordination.py
@@ -222,18 +222,18 @@ def synchronized(lock_name, blocking=True, coordinator=None):
 
 
 def _get_redis_backend_url():
-    password = getattr(CONF.coordination, 'backend_password', None)
-    if password is not None:
+    cipher_password = getattr(CONF.coordination, 'backend_password', None)
+    if cipher_password is not None:
         # If password is needed, the password should be
         # set in config file with cipher text
         # And in this scenario, these are also needed for backend:
         # {backend_type}://[{user}]:{password}@{ip}:{port}.
-        plaintext_password = cryptor.decode(password)
+        plaintext_password = cryptor.decode(cipher_password)
         # User could be null
         backend_url = '{backend_type}://{user}:{password}@{server}' \
             .format(backend_type=CONF.coordination.backend_type,
-                    user=getattr(CONF.coordination, 'backend_user'),
-                    password=plaintext_password.decode('utf-8'),
+                    user=CONF.coordination.backend_user,
+                    password=plaintext_password,
                     server=CONF.coordination.backend_server)
 
     else:

--- a/dolphin/cryptor.py
+++ b/dolphin/cryptor.py
@@ -38,11 +38,25 @@ class _Base64(ICryptor):
 
     @staticmethod
     def encode(data):
-        return base64.b64encode(data.encode())
+        """Base64 encode
+
+        :param data: The plain text that need to be encode
+        :type str:
+        :return cipher data: The encoded cipher text
+        :type str:
+        """
+        return base64.b64encode(data.encode()).decode('utf-8')
 
     @staticmethod
     def decode(data):
-        return base64.b64decode(data)
+        """Base64 decode
+
+        :param data: The cipher text that need to be decode
+        :type str:
+        :return plain data: The decoded plain text
+        :type str:
+        """
+        return base64.b64decode(data).decode('utf-8')
 
 
 _cryptor = importutils.import_class(CONF.dolphin_cryptor)

--- a/dolphin/test.py
+++ b/dolphin/test.py
@@ -114,7 +114,9 @@ class TestCase(base_test.BaseTestCase):
         fake_notifier.stub_notifier(self)
 
         # Locks must be cleaned up after tests
-        CONF.set_override('backend_url', 'file://' + lock_path,
+        CONF.set_override('backend_type', 'file',
+                          group='coordination')
+        CONF.set_override('backend_server', lock_path,
                           group='coordination')
         coordination.LOCK_COORDINATOR.start()
         self.addCleanup(coordination.LOCK_COORDINATOR.stop)

--- a/dolphin/test.py
+++ b/dolphin/test.py
@@ -32,6 +32,7 @@ from oslo_messaging import conffixture as messaging_conffixture
 from oslo_utils import uuidutils
 import oslotest.base as base_test
 
+from dolphin.common import config  # noqa
 from dolphin import coordination
 from dolphin.db.sqlalchemy import api as db_api
 from dolphin.db.sqlalchemy import models as db_models


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Now the backend info is fixed in code, but it should be able to be configured.
Add related configuration for Tooz backend

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Now the default configuration is for redis without password
And you can add the configuration in `dolphin.conf` like this
```release-note
[coordination]
backend_type = {backend_type}
backend_user = {backend_user}
# This should be cipher text, now the encryption algorithm is base64
# You can get the cipher text by any online base64 encryption tool
backend_password = {backend_password}
backend_server = {backend_server}
```
