### PR TITLE
Update storage_id to VMAX pool model

### DIFF
--- a/dolphin/drivers/dell_emc/vmax/client.py
+++ b/dolphin/drivers/dell_emc/vmax/client.py
@@ -93,7 +93,7 @@ class VMAXClient(object):
             LOG.error(msg)
             raise exception.StorageBackendException(msg)
 
-    def list_storage_pools(self):
+    def list_storage_pools(self, storage_id):
 
         try:
             # Get list of SRP pool names
@@ -109,6 +109,7 @@ class VMAXClient(object):
 
                 p = {
                     "name": pool,
+                    "storage_id": storage_id,
                     "original_id": pool_info["srpId"],
                     "description": "Dell EMC VMAX Pool",
                     "status": constants.StoragePoolStatus.NORMAL,

--- a/dolphin/drivers/dell_emc/vmax/vmax.py
+++ b/dolphin/drivers/dell_emc/vmax/vmax.py
@@ -61,7 +61,7 @@ class VMAXStorageDriver(driver.StorageDriver):
         return storage
 
     def list_storage_pools(self, context):
-        return self.client.list_storage_pools()
+        return self.client.list_storage_pools(self.storage_id)
 
     def list_volumes(self, context):
         return self.client.list_volumes(self.storage_id)


### PR DESCRIPTION
Add storage_id to VMAX driver returned pool model.

**What this PR does / why we need it**:
This PR fixes issue #154 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
