### PR TITLE
Add provisioning policy for VMAX volumes

### DIFF
--- a/dolphin/drivers/dell_emc/vmax/client.py
+++ b/dolphin/drivers/dell_emc/vmax/client.py
@@ -166,6 +166,7 @@ class VMAXClient(object):
                     "status": status,
                     "original_id": vol['volumeId'],
                     "wwn": vol['wwn'],
+                    "provisioning_policy": constants.ProvisioningPolicy.THIN,
                     "total_capacity": int(total_cap),
                     "used_capacity": int(used_cap),
                     "free_capacity": int(free_cap),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add provisioning policy for VMAX volumes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #155 


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
