### PR TITLE
Adding unit test for access_info

### DIFF
--- a/dolphin/tests/unit/api/fakes.py
+++ b/dolphin/tests/unit/api/fakes.py
@@ -16,6 +16,7 @@
 
 import webob.dec
 import webob.request
+from dolphin.db.sqlalchemy import models
 
 from dolphin import context
 from dolphin.api.common import wsgi as os_wsgi
@@ -143,3 +144,37 @@ def fake_access_info_get_all(context, marker=None, limit=None, sort_keys=None,
 
 def fake_sync(self, req, id):
     pass
+
+
+def fake_access_info__show(context, storage_id):
+    access_info = models.AccessInfo()
+
+    access_info.updated_at = '2020-06-15T09:50:31.698956'
+    access_info.storage_id = '865ffd4d-f1f7-47de-abc3-5541ef44d0c1'
+    access_info.created_at = '2020-06-15T09:50:31.698956'
+    access_info.vendor = 'fake_storage'
+    access_info.model = 'fake_driver'
+    access_info.host = '10.0.0.0'
+    access_info.username = 'admin'
+    access_info.password = 'YWJjZA=='
+    access_info.port = '1234'
+    access_info.extra_attributes = {'array_id': '0001234567897'}
+
+    return access_info
+
+
+def fake_update_access_info(self, context, access_info):
+    access_info = models.AccessInfo()
+
+    access_info.updated_at = '2020-06-15T09:50:31.698956'
+    access_info.storage_id = '865ffd4d-f1f7-47de-abc3-5541ef44d0c1'
+    access_info.created_at = '2020-06-15T09:50:31.698956'
+    access_info.vendor = 'fake_storage'
+    access_info.model = 'fake_driver'
+    access_info.host = '10.0.0.0'
+    access_info.username = 'admin_modified'
+    access_info.password = 'YWJjZA=='
+    access_info.port = '1234'
+    access_info.extra_attributes = {'array_id': '0001234567897'}
+
+    return access_info

--- a/dolphin/tests/unit/api/v1/test_access_info.py
+++ b/dolphin/tests/unit/api/v1/test_access_info.py
@@ -1,0 +1,100 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from dolphin import db
+from dolphin import exception
+from dolphin import test
+from dolphin.api.v1.access_info import AccessInfoController
+from dolphin.tests.unit.api import fakes
+
+
+class TestAccessInfoController(test.TestCase):
+
+    def setUp(self):
+        super(TestAccessInfoController, self).setUp()
+        self.driver_api = mock.Mock()
+        self.controller = AccessInfoController()
+        self.mock_object(self.controller, 'driver_api', self.driver_api)
+
+    def test_show(self):
+        self.mock_object(
+            db, 'access_info_get',
+            fakes.fake_access_info__show)
+        req = fakes.HTTPRequest.blank(
+            '/storages/865ffd4d-f1f7-47de-abc3-5541ef44d0c1/access-info')
+
+        res_dict = self.controller.show(
+            req, '865ffd4d-f1f7-47de-abc3-5541ef44d0c1')
+        expctd_dict = {
+            "model": "fake_driver",
+            "vendor": "fake_storage",
+            "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
+            "port": "1234",
+            "host": "10.0.0.0",
+            "extra_attributes": {
+                "array_id": "0001234567897"
+            },
+            "created_at": "2020-06-15T09:50:31.698956",
+            "updated_at": "2020-06-15T09:50:31.698956",
+            "username": "admin"
+        }
+
+        self.assertDictEqual(expctd_dict, res_dict)
+
+    def test_show_with_invalid_id(self):
+        self.mock_object(
+            db, 'access_info_get',
+            mock.Mock(side_effect=exception.AccessInfoNotFound('fake_id')))
+        req = fakes.HTTPRequest.blank('/storages/fake_id/access-info')
+        self.assertRaises(exception.AccessInfoNotFound,
+                          self.controller.show,
+                          req, 'fake_id')
+
+    def test_access_info_update(self):
+        self.mock_object(
+            db, 'access_info_get',
+            fakes.fake_access_info__show)
+
+        fake_access_info = fakes.fake_update_access_info(None, None, None)
+        self.mock_object(
+            self.controller.driver_api, 'update_access_info',
+            mock.Mock(return_value=fake_access_info))
+
+        body = {
+            'username': 'admin_modified',
+            'extra_attributes': {'array_id': '0001234567891'},
+            'password': 'abcd_modified',
+            'host': '10.0.0.0',
+            'port': 1234
+        }
+        req = fakes.HTTPRequest.blank(
+            '/storages/865ffd4d-f1f7-47de-abc3-5541ef44d0c1/access-info')
+        res_dict = self.controller.update(
+            req, '865ffd4d-f1f7-47de-abc3-5541ef44d0c1', body=body)
+        expctd_dict = {
+            "model": "fake_driver",
+            "vendor": "fake_storage",
+            "storage_id": "865ffd4d-f1f7-47de-abc3-5541ef44d0c1",
+            "port": "1234",
+            "host": "10.0.0.0",
+            "extra_attributes": {
+                "array_id": "0001234567897"
+            },
+            "created_at": "2020-06-15T09:50:31.698956",
+            "updated_at": "2020-06-15T09:50:31.698956",
+            "username": "admin_modified"
+        }
+        self.assertDictEqual(expctd_dict, res_dict)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
unit test for /v1/api/access-info 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #177 

**Special notes for your reviewer**:
NA
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
